### PR TITLE
StaticPropLumpV5 + V4

### DIFF
--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -542,7 +542,7 @@ where
         })
 }
 
-#[derive(Debug, Copy, Clone, BinRead)]
+#[derive(Debug, Copy, Clone, BinRead, Default)]
 pub struct Angles {
     pitch: f32,
     yaw: f32,


### PR DESCRIPTION
I hope I got this right?  It seems to work with the maps I've tested, not sure if there is too many items in the `StaticPropLumpFlagsV5` flags since I don't know what the V5 signifies in reference to the valve developer documentation.

This also seems like quite a bit of duplicate code and default values, perhaps there is a better way to do it with enums or something.  Maybe the flags should both use the same struct at least?