### PR TITLE
BspFile Changes

### DIFF
--- a/src/bspfile.rs
+++ b/src/bspfile.rs
@@ -11,23 +11,8 @@ pub struct BspFile<'a> {
 
 impl<'a> BspFile<'a> {
     pub fn new(data: &'a [u8]) -> BspResult<Self> {
-        const EXPECTED_HEADER: Header = Header {
-            v: b'V',
-            b: b'B',
-            s: b'S',
-            p: b'P',
-        };
-        // TODO: Use this to decide on the version to parse it as
-        const EXPECTED_VERSION: u32 = 0x14;
-
         let mut cursor = Cursor::new(data);
         let header: Header = cursor.read_le()?;
-        let version: u32 = cursor.read_le()?;
-
-        if header != EXPECTED_HEADER || version != EXPECTED_VERSION {
-            return Err(BspError::UnexpectedHeader(header));
-        }
-
         let directories = cursor.read_le()?;
 
         Ok(BspFile {

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -71,11 +71,16 @@ impl Index<LumpType> for Directories {
 
 #[derive(Debug, Clone, PartialEq, Eq, BinRead)]
 #[br(little)]
+#[brw(repr=u32)]
+pub enum BspVersion {
+    Version20 = 20,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BinRead)]
+#[br(little)]
 pub struct Header {
-    pub v: u8,
-    pub b: u8,
-    pub s: u8,
-    pub p: u8,
+    #[brw(magic = b"VBSP")]
+    pub version: BspVersion,
 }
 
 #[derive(Clone, Copy, Debug, Default, BinRead)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,8 +7,6 @@ use zip::result::ZipError;
 #[non_exhaustive]
 #[derive(Debug, Error)]
 pub enum BspError {
-    #[error("unexpected magic numbers or version")]
-    UnexpectedHeader(Header),
     #[error("bsp lump is out of bounds of the bsp file")]
     LumpOutOfBounds(LumpEntry),
     #[error("bsp game lump is out of bounds of the bsp file")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,6 +7,8 @@ use zip::result::ZipError;
 #[non_exhaustive]
 #[derive(Debug, Error)]
 pub enum BspError {
+    #[error("unexpected magic numbers or version: {0:?}")]
+    UnexpectedHeader([u8; 4]),
     #[error("bsp lump is out of bounds of the bsp file")]
     LumpOutOfBounds(LumpEntry),
     #[error("bsp game lump is out of bounds of the bsp file")]


### PR DESCRIPTION
- Version number is moved into `Header`.
- Version number is an enum consisting of supported bsp versions.
- "VBSP" FourCC is decoded as a magic number, expected in all files.
- IBSP and big endianness remains ignored.

I'm investigating version 19 which seems to have some lump size differences, I'll add that in another pull request that depends on this one.

NOTE: As written, an invalid header shows up as a binrw error, and no longer has its own error variant.