### PR TITLE
use Leaves constructor in Leaves BinRead

### DIFF
--- a/src/data/leaves.rs
+++ b/src/data/leaves.rs
@@ -87,7 +87,7 @@ impl BinRead for Leaves {
             )?);
         }
 
-        Ok(Self { leaves: entries })
+        Ok(Self::new(entries))
     }
 }
 


### PR DESCRIPTION
I noticed that the leaves are supposed to be sorted by the constructor and that was skipped in the new code.