### PR TITLE
Use split_at in EntitiesIter

### DIFF
--- a/src/data/entity.rs
+++ b/src/data/entity.rs
@@ -38,12 +38,11 @@ impl<'a> Iterator for EntitiesIter<'a> {
 
     fn next(&mut self) -> Option<Self::Item> {
         let start = self.buf.find('{')?;
-        let end = start + self.buf[start..].find('}')?;
+        let slice = &self.buf[start..];
+        let end = start + slice.find('}')?;
+        let (out, rest) = slice.split_at(end + 1);
 
-        let out = &self.buf[start..end + 1];
-
-        self.buf = &self.buf[end + 1..];
-
+        self.buf = rest;
         Some(RawEntity { buf: out })
     }
 }

--- a/src/data/entity.rs
+++ b/src/data/entity.rs
@@ -39,7 +39,7 @@ impl<'a> Iterator for EntitiesIter<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         let start = self.buf.find('{')?;
         let slice = &self.buf[start..];
-        let end = start + slice.find('}')?;
+        let end = slice.find('}')?;
         let (out, rest) = slice.split_at(end + 1);
 
         self.buf = rest;


### PR DESCRIPTION
This code irritated me because I knew about split_at.  I tested it with one map and no entities seemed to be missing.

Edit: The entities codegen is finding a bunch of extra tf2 fields with this change???  I didn't intend for this to behave any different so this is surprising.  There is also two fields which are removed, see here for details: https://github.com/krakow10/vbsp-entities/tree/entities-iter-split_at

Interestingly, it produces the exact same output as before when I feed 20 css maps and 55 bhop maps, so the weirdness is only affecting tf2 entity parsing.

Edit2: Fixed the bug, it only messed up when there was whitespace between entities.