### PR TITLE
Change StaticPropLump & Angles Fields Visibility to Public

### DIFF
--- a/common/src/bool.rs
+++ b/common/src/bool.rs
@@ -1,5 +1,5 @@
-use serde::Deserializer;
 use serde::de::{Error, Unexpected};
+use serde::Deserializer;
 use std::fmt;
 
 struct BoolVisitor;

--- a/src/data/game.rs
+++ b/src/data/game.rs
@@ -2,7 +2,6 @@ use crate::error::UnsupportedLumpVersion;
 use crate::{lzma_decompress_with_header, Angles, BspError, FixedString, Vector};
 use binrw::{BinRead, BinReaderExt, BinResult, Endian};
 use bitflags::bitflags;
-use cgmath::Quaternion;
 use std::borrow::Cow;
 use std::io::{Cursor, Read, Seek};
 
@@ -120,7 +119,7 @@ pub struct StaticPropLumps {
 #[derive(Debug, Clone, Default)]
 pub struct StaticPropLump {
     pub origin: Vector,
-    angles: Angles,
+    pub angles: Angles,
     pub prop_type: u16,
     pub first_leaf: u16,
     pub leaf_count: u16,
@@ -134,13 +133,6 @@ pub struct StaticPropLump {
     pub max_dx_level: u16,
     pub flags: StaticPropLumpFlags,
     pub lightmap_resolution: [u16; 2],
-}
-
-impl StaticPropLump {
-    /// Get the rotation of the prop as quaternion
-    pub fn rotation(&self) -> Quaternion<f32> {
-        self.angles.as_quaternion()
-    }
 }
 
 impl BinRead for StaticPropLump {

--- a/src/data/prop.rs
+++ b/src/data/prop.rs
@@ -5,7 +5,7 @@ impl<'a> AsPropPlacement<'a> for Handle<'a, StaticPropLump> {
     fn as_prop_placement(&self) -> PropPlacement<'a> {
         PropPlacement {
             model: self.model(),
-            rotation: self.rotation(),
+            rotation: self.angles.as_quaternion(),
             scale: 1.0,
             origin: self.origin,
             skin: self.skin,


### PR DESCRIPTION
I need to swap the Z-up coordinates to Y-up, and it's more convenient to do so with angles than quaternions.