### PR TITLE
Add BSP v21 support (excluding L4D2)

### DIFF
--- a/src/data/game.rs
+++ b/src/data/game.rs
@@ -144,7 +144,7 @@ impl BinRead for StaticPropLump {
         args: Self::Args<'static>,
     ) -> BinResult<Self> {
         match args.0 {
-            4..=7 | 10 => {
+            4..=7 | 9 | 10  => {
                 RawStaticPropLump::read_options(reader, endian, (args.0,)).map(StaticPropLump::from)
             }
             version => Err(binrw::Error::Custom {

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -78,6 +78,7 @@ impl Index<LumpType> for Directories {
 pub enum BspVersion {
     Version19 = 19,
     Version20 = 20,
+    Version21 = 21,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, BinRead)]


### PR DESCRIPTION
This PR adds initial support for parsing BSP version 21 files.

It has been verified to work correctly with maps from:
*   Portal 2
*   The Stanley Parable
*   Alien Swarm
*   Counter-Strike: Global Offensive (outdated)

For my use cases involving these games, the parsing appears fully functional. If you believe otherwise or encounter issues with maps from these (or other potentially compatible v21 games, excluding L4D2), please let me know.

**Important Limitation: Left 4 Dead 2 Incompatibility**

Please note that Left 4 Dead 2 maps, while also using BSP version 21, are **not supported** by this implementation and will likely fail to parse.

This is due to L4D2 apparently using a different field order within its `lump_t` structure (the directory entries in the BSP header). L4D2 seems to use `{version, fileofs, filelen, fourCC}`, whereas v19, v20, and the other tested v21 games use the standard `{fileofs, filelen, version, fourCC}` order, which this implementation follows.